### PR TITLE
getStdOperationInput: Revert back to Existing solution template

### DIFF
--- a/opt-mngmnt/getStdOperationInput.js
+++ b/opt-mngmnt/getStdOperationInput.js
@@ -1,3 +1,6 @@
+/*
+// New solution template
+
 const express = require('express');
 const sql = require('mssql');
 const dbConfig = require('../dbConfig');
@@ -26,6 +29,31 @@ router.post('/getStdOperationInput', async (req, res) => {
     console.error('SQL Error:', err);
     res.status(500).json({ message: err.message });
   }
+});
+
+module.exports = router;
+*/
+
+// Using Existing solution template
+const express = require('express');
+const sql = require('mssql');
+const dbConfig = require('../dbConfig');
+const router = express.Router();
+
+sql.connect(dbConfig).then(() => {
+    router.get('/getStdOperationInput', async (req, res) => {
+        try {
+            const result = await sql.query(`
+            EXEC [dbo].[UI_Std_Operation_Input]
+                  @Game_Id = '${req.query.gameId}',
+                  @Game_Batch = ${req.query.gameBatch},
+                  @Game_Team = '${req.query.gameTeam}'`);
+            res.json(result.recordset);
+        } catch (err) {
+            console.error('Query failed:', err);
+            res.status(500).send('Internal Server Error');
+        }
+    });
 });
 
 module.exports = router;


### PR DESCRIPTION
New Solution Template with paramTypes and bindParams throws error.
So, existing solution template (as used in other pages) is used.